### PR TITLE
Qt5 package installation removes Qt4 version

### DIFF
--- a/rpm/connectionagent-qt5.spec
+++ b/rpm/connectionagent-qt5.spec
@@ -9,7 +9,7 @@ Name:       connectionagent-qt5
 # << macros
 
 Summary:    User Agent daemon
-Version:    0.7.6
+Version:    0.7.7
 Release:    0
 Group:      Communications/Connectivity Adaptation
 License:    LGPLv2
@@ -23,6 +23,10 @@ BuildRequires:  pkgconfig(connman-qt5)
 BuildRequires:  pkgconfig(Qt5Network)
 BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(Qt5Qml)
+Provides:   connectionagent > 0.7.6
+Provides:   connectionagent-declarative > 0.7.6
+Obsoletes:   connectionagent <= 0.7.6
+Obsoletes:   connectionagent-declarative <= 0.7.6
 
 %description
 Connection Agent provides multi user access to connman's User Agent.

--- a/rpm/connectionagent-qt5.yaml
+++ b/rpm/connectionagent-qt5.yaml
@@ -1,6 +1,6 @@
 Name: connectionagent-qt5
 Summary: User Agent daemon
-Version: 0.7.6
+Version: 0.7.7
 Release: 0
 Group: "Communications/Connectivity Adaptation"
 License: LGPLv2
@@ -13,7 +13,13 @@ Sources:
     - "%{name}-%{version}.tar.bz2"
 Requires:
     - connman-qt5-declarative
-    
+Obsoletes:
+    - connectionagent <= 0.7.6
+    - connectionagent-declarative <= 0.7.6
+Provides:
+    - connectionagent > 0.7.6
+    - connectionagent-declarative > 0.7.6
+
 PkgConfigBR:
     - Qt5Core
     - Qt5DBus


### PR DESCRIPTION
- Minor fix to avoid conflicts.
