### PR TITLE
Fix Qt 4 package builds

### DIFF
--- a/connectionagent.pro
+++ b/connectionagent.pro
@@ -4,8 +4,6 @@ SUBDIRS += connectionagentplugin
 SUBDIRS += test
 
 equals(QT_MAJOR_VERSION, 4):  {
-    SUBDIRS += config
-    SUBDIRS += connd
     SUBDIRS += test/testqml
     OTHER_FILES += rpm/connectionagent.spec \
                    rpm/connectionagent.yaml


### PR DESCRIPTION
...es.

This was removed in 1c48fd1537677fff27fe723813ab868c01b87d0d, and apparently
accidentally readded in 32c7c35f0177a3acfce7d1c2e84edcfa2457f699.
