### PR TITLE
[connectionagent] Fix segfault when no network services are available.

### DIFF
--- a/connd/qconnectionmanager.cpp
+++ b/connd/qconnectionmanager.cpp
@@ -539,7 +539,7 @@ void QConnectionManager::networkStateChanged(const QString &state)
         //automigrate
         QString bestService = findBestConnectableService();
 
-        if (servicesMap.value(bestService)->type() != "ethernet") {
+        if (!bestService.isEmpty() && servicesMap.value(bestService)->type() != "ethernet") {
             connectionHandover(connectedServices.isEmpty() ? QString() : connectedServices.at(0),
                                bestService);
         }


### PR DESCRIPTION
If no network services are available findBestConnectableService()
returns an empty string, which is not a valid key for the servicesMap.
