### PR TITLE
[connectionagent] Minimise number of times services are updated.

### DIFF
--- a/connd/qconnectionmanager.cpp
+++ b/connd/qconnectionmanager.cpp
@@ -92,8 +92,7 @@ QConnectionManager::QConnectionManager(QObject *parent) :
     connect(ua,SIGNAL(browserRequested(QString,QString)),
             this,SLOT(browserRequest(QString,QString)), Qt::UniqueConnection);
 
-    connect(netman,SIGNAL(serviceAdded(QString)),this,SLOT(onServiceAdded(QString)));
-    connect(netman,SIGNAL(serviceRemoved(QString)),this,SLOT(onServiceRemoved(QString)));
+    connect(netman,SIGNAL(servicesChanged()),this,SLOT(onServicesChanged()));
     connect(netman,SIGNAL(stateChanged(QString)),this,SLOT(networkStateChanged(QString)));
     connect(netman,SIGNAL(servicesChanged()),this,SLOT(setup()));
 
@@ -181,21 +180,8 @@ void QConnectionManager::sendUserReply(const QVariantMap &input)
     ua->sendUserReply(input);
 }
 
-void QConnectionManager::onServiceAdded(const QString &servicePath)
+void QConnectionManager::onServicesChanged()
 {
-    qDebug() << Q_FUNC_INFO << servicePath;
-    if (!servicesMap.contains(servicePath)) {
-        updateServicesMap();
-    }
-    //automigrate
-    // is network is connected, is this a better one?
-    if (servicesMap.value(servicePath)->autoConnect())
-            autoConnect();
-}
-
-void QConnectionManager::onServiceRemoved(const QString &servicePath)
-{
-    qDebug() << Q_FUNC_INFO << servicePath;
     updateServicesMap();
     if (!handoverInProgress)
         autoConnect();

--- a/connd/qconnectionmanager.h
+++ b/connd/qconnectionmanager.h
@@ -106,8 +106,7 @@ private slots:
     void onScanFinished();
     void updateServicesMap();
 
-    void onServiceAdded(const QString &servicePath);
-    void onServiceRemoved(const QString &servicePath);
+    void onServicesChanged();
     void serviceErrorChanged(const QString &error);
     void serviceStateChanged(const QString &state);
     void networkStateChanged(const QString &state);


### PR DESCRIPTION
Every time a connman service was added or removed connection agent
would clear and reload the entire service list. Instead of connecting
to the serviceAdded and serviceRemoved signals just connect to
servicesChanged().

This ends up bypassing an issue in connman-qt where serviceAdded is
sometimes not emitted for every added service. Causing a delay between
when a service is available and an auto connect attempt is made.
Usually after a service is removed.
