### PR TITLE
[connectionagent] use mce via dbus for display state signaling,

### DIFF
--- a/connd/connd.pro
+++ b/connd/connd.pro
@@ -26,11 +26,13 @@ OTHER_FILES += com.jolla.Connectiond.xml
 
 SOURCES += main.cpp \
     qconnectionmanager.cpp \
-    connadaptor.cpp
+    connadaptor.cpp \
+    wakeupwatcher.cpp
 
 HEADERS+= \
     qconnectionmanager.h \
-    connadaptor.h
+    connadaptor.h \
+    wakeupwatcher.h
 
 target.path = /usr/bin
 INSTALLS += target

--- a/connd/qconnectionmanager.h
+++ b/connd/qconnectionmanager.h
@@ -34,7 +34,7 @@ class NetworkManager;
 class NetworkService;
 class QOfonoConnectionContext;
 class NetworkTechnology;
-
+class WakeupWatcher;
 class QConnectionManager : public QObject
 {
     Q_OBJECT
@@ -109,7 +109,7 @@ private:
     NetworkTechnology *tetheringWifiTech;
     bool tetheringEnabled;
     bool flightModeSuppression;
-
+WakeupWatcher *mceWatch;
 private slots:
     void onScanFinished();
     void updateServicesMap();
@@ -138,6 +138,10 @@ private slots:
     void servicesListChanged(const QStringList &);
     void offlineModeChanged(bool);
     void flightModeDialogSuppressionTimeout();
+
+    void displayStateChanged(const QString &);
+    void sleepStateChanged(bool);
+
 };
 
 #endif // QCONNECTIONMANAGER_H

--- a/connd/wakeupwatcher.cpp
+++ b/connd/wakeupwatcher.cpp
@@ -1,0 +1,71 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Jolla Ltd
+** Contact: lorn.potter@gmail.com
+**
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+****************************************************************************/
+
+#include <QDBusPendingReply>
+#include <QDebug>
+
+#include "wakeupwatcher.h"
+
+WakeupWatcher::WakeupWatcher(QObject *parent) :
+    QObject(parent),
+    currentPowerSave(false)
+{
+    mceInterface = new QDBusInterface(MCE_SERVICE,
+                                      MCE_SIGNAL_PATH,
+                                      MCE_SIGNAL_INTERFACE,
+                                      QDBusConnection::systemBus(),
+                                      parent);
+
+    mceInterface->connection().connect(MCE_SERVICE,
+                                       MCE_SIGNAL_PATH,
+                                       MCE_SIGNAL_INTERFACE,
+                                       MCE_PSM_STATE_IND,
+                                       this,
+                                       SLOT(mceSleepStateChanged(bool)));
+
+    mceInterface->connection().connect(MCE_SERVICE,
+                                       MCE_SIGNAL_PATH,
+                                       MCE_SIGNAL_INTERFACE,
+                                       MCE_DISPLAY_IND,
+                                       this,
+                                       SLOT(mceDisplayStateChanged(const QString)));
+
+    QDBusPendingReply<QString> displayStateReply = QDBusConnection::systemBus().call(
+                QDBusMessage::createMethodCall(MCE_SERVICE,
+                                               MCE_REQUEST_PATH,
+                                               MCE_REQUEST_INTERFACE,
+                                               MCE_DISPLAY_STATUS_GET));
+    displayStateReply.waitForFinished();
+    if (displayStateReply.isValid()) {
+        currentDisplayState = displayStateReply.value();
+    }
+}
+
+void WakeupWatcher::mceDisplayStateChanged(const QString &state)
+{
+    if (state != currentDisplayState) {
+        currentDisplayState = state;
+        emit displayStateChanged(currentDisplayState);
+    }
+}
+
+void WakeupWatcher::mceSleepStateChanged(bool mode)
+{
+    if (mode != currentPowerSave) {
+        currentPowerSave = mode;
+        emit sleepStateChanged(currentPowerSave);
+    }
+}

--- a/connd/wakeupwatcher.h
+++ b/connd/wakeupwatcher.h
@@ -1,0 +1,54 @@
+/****************************************************************************
+**
+** Copyright (C) 2013 Jolla Ltd
+** Contact: lorn.potter@gmail.com
+**
+**
+** GNU Lesser General Public License Usage
+** This file may be used under the terms of the GNU Lesser
+** General Public License version 2.1 as published by the Free Software
+** Foundation and appearing in the file LICENSE.LGPL included in the
+** packaging of this file.  Please review the following information to
+** ensure the GNU Lesser General Public License version 2.1 requirements
+** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
+**
+****************************************************************************/
+
+#ifndef WAKEUPWATCHER_H
+#define WAKEUPWATCHER_H
+
+#include <QObject>
+#include <QDBusInterface>
+
+#define MCE_SERVICE                     "com.nokia.mce"
+#define MCE_SIGNAL_PATH                 "/com/nokia/mce/signal"
+#define MCE_SIGNAL_INTERFACE            "com.nokia.mce.signal"
+#define MCE_PSM_STATE_IND               "psm_state_ind"
+#define MCE_DISPLAY_IND                 "display_status_ind"
+
+#define MCE_REQUEST_PATH                "/com/nokia/mce/request"
+#define MCE_REQUEST_INTERFACE           "com.nokia.mce.request"
+#define MCE_DISPLAY_STATUS_GET          "get_display_status"
+#define MCE_PSM_STATE_GET               "get_psm_state"
+
+class WakeupWatcher : public QObject
+{
+    Q_OBJECT
+public:
+    explicit WakeupWatcher(QObject *parent = 0);
+
+signals:
+    void displayStateChanged(const QString&);
+    void sleepStateChanged(bool);
+public slots:
+
+private slots:
+    void mceDisplayStateChanged(const QString &state);
+    void mceSleepStateChanged(bool mode);
+private:
+    QDBusInterface *mceInterface;
+    QString currentDisplayState;
+    bool currentPowerSave;
+};
+
+#endif // WAKEUPWATCHER_H

--- a/test/auto/tst_connectionagent/tst_connectionagent.pro
+++ b/test/auto/tst_connectionagent/tst_connectionagent.pro
@@ -11,11 +11,13 @@ DEFINES += SRCDIR=\\\"$$PWD/\\\"
 
 SOURCES += tst_connectionagent.cpp \
         ../../../connd/qconnectionmanager.cpp \
-        ../../../connd/connadaptor.cpp
+        ../../../connd/connadaptor.cpp \
+        ../../../connd/wakeupwatcher.cpp
 
 HEADERS += \
         ../../../connd/qconnectionmanager.h \
-        ../../../connd/connadaptor.h
+        ../../../connd/connadaptor.h \
+        ../../../connd/wakeupwatcher.h
 
 INCLUDEPATH += ../../../connd
 


### PR DESCRIPTION
to be able to do things such as start a scan when needed.
