### PR TITLE
[connectionagent] clear last connected service when something

### DIFF
--- a/connd/qconnectionmanager.h
+++ b/connd/qconnectionmanager.h
@@ -35,6 +35,8 @@ class NetworkService;
 class QOfonoConnectionContext;
 class NetworkTechnology;
 class WakeupWatcher;
+class QTimer;
+
 class QConnectionManager : public QObject
 {
     Q_OBJECT
@@ -110,6 +112,7 @@ private:
     bool tetheringEnabled;
     bool flightModeSuppression;
 WakeupWatcher *mceWatch;
+QTimer *goodConnectTimer;
 private slots:
     void onScanFinished();
     void updateServicesMap();
@@ -141,6 +144,8 @@ private slots:
 
     void displayStateChanged(const QString &);
     void sleepStateChanged(bool);
+
+    void connectionTimeout();
 
 };
 


### PR DESCRIPTION
requests a connection.

This allows the autoconnect service to be disconnected, but
also allows it to reconnect if a connection request comes from
connman.
