### PR TITLE
[connectionagent] really set timeupdates to manual.

### DIFF
--- a/connd/qconnectionmanager.cpp
+++ b/connd/qconnectionmanager.cpp
@@ -24,7 +24,6 @@
 #include <connman-qt5/networktechnology.h>
 #include <connman-qt5/networkservice.h>
 #include <connman-qt5/sessionagent.h>
-#include <connman-qt5/clockmodel.h>
 #include <qofono-qt5/qofonoconnectioncontext.h>
 #include <qofono-qt5/qofonoconnectionmanager.h>
 #include <qofono-qt5/qofononetworkregistration.h>
@@ -83,6 +82,7 @@ QConnectionManager::QConnectionManager(QObject *parent) :
 
     askForRoaming = askRoaming();
 
+    connect(&clockModel,SIGNAL(timeUpdatesChanged()),this,SLOT(timeUpdatesChanged()));
     ua = new UserAgent(this);
 
     connect(ua,SIGNAL(userInputRequested(QString,QVariantMap)),
@@ -600,6 +600,14 @@ void QConnectionManager::serviceRemoved(const QString &srv)
         serviceInProgress.clear();
 }
 
+void QConnectionManager::timeUpdatesChanged()
+{
+    qDebug();
+    clockModel.setTimeUpdates("manual");
+    clockModel.setTimezoneUpdates("manual");
+    disconnect(&clockModel,SIGNAL(timeUpdatesChanged()),this,SLOT(timeUpdatesChanged()));
+}
+
 void QConnectionManager::setup()
 {
     qDebug() << Q_FUNC_INFO
@@ -610,9 +618,6 @@ void QConnectionManager::setup()
                  << netman->state()
                  << netman->defaultRoute()->type();
 
-        ClockModel clockModel;
-        clockModel.setTimeUpdates("manual");
-        clockModel.setTimezoneUpdates("manual");
 
         techChanged();
         connect(netman,SIGNAL(technologiesChanged()),this,SLOT(techChanged()));

--- a/connd/qconnectionmanager.h
+++ b/connd/qconnectionmanager.h
@@ -25,6 +25,7 @@
 #include <QDBusObjectPath>
 #include <QQueue>
 #include <QPair>
+#include <connman-qt5/clockmodel.h>
 
 class UserAgent;
 class SessionAgent;
@@ -111,8 +112,10 @@ private:
     NetworkTechnology *tetheringWifiTech;
     bool tetheringEnabled;
     bool flightModeSuppression;
-WakeupWatcher *mceWatch;
-QTimer *goodConnectTimer;
+    WakeupWatcher *mceWatch;
+    QTimer *goodConnectTimer;
+    ClockModel clockModel;
+
 private slots:
     void onScanFinished();
     void updateServicesMap();
@@ -147,6 +150,7 @@ private slots:
 
     void connectionTimeout();
     void serviceAutoconnectChanged(bool);
+    void timeUpdatesChanged();
 
 };
 


### PR DESCRIPTION
We need to wait for first update to ensure that the clockmodel is
connected to connman, then we set them to manual.
