### PR TITLE
[connectionagent] Fix crash when turning on display.

### DIFF
--- a/connd/qconnectionmanager.cpp
+++ b/connd/qconnectionmanager.cpp
@@ -756,7 +756,7 @@ void QConnectionManager::displayStateChanged(const QString &state)
 {
     if (state == "on") {
         NetworkTechnology *wifiTech = netman->getTechnology("wifi");
-        if (wifiTech->powered() && !wifiTech->connected()) {
+        if (wifiTech && wifiTech->powered() && !wifiTech->connected()) {
             previousConnectedService.clear();
             wifiTech->scan();
         }


### PR DESCRIPTION
Prevent crash in the event that wifi technology is not available when
the display is turned on.
