### PR TITLE
    [connectionagent] try harder to find a wlan. this adds a scan timer

### DIFF
--- a/connd/qconnectionmanager.cpp
+++ b/connd/qconnectionmanager.cpp
@@ -64,7 +64,8 @@ QConnectionManager::QConnectionManager(QObject *parent) :
      oContext(0),
      tetheringWifiTech(0),
      tetheringEnabled(false),
-     flightModeSuppression(false)
+     flightModeSuppression(false),
+     scanTimeoutInterval(1)
 {
     qDebug() << Q_FUNC_INFO;
 
@@ -130,7 +131,6 @@ QConnectionManager::QConnectionManager(QObject *parent) :
     goodConnectTimer->setSingleShot(true);
     goodConnectTimer->setInterval(12 * 1000);
     connect(goodConnectTimer,SIGNAL(timeout()),this,SLOT(connectionTimeout()));
-
 }
 
 QConnectionManager::~QConnectionManager()
@@ -201,10 +201,12 @@ void QConnectionManager::servicesListChanged(const QStringList &list)
         if (orderedServicesList.indexOf((path)) == -1) {
          //added
             qDebug() << Q_FUNC_INFO << "added" << path;
-            serviceAdded(path);
             ok = true;
         }
     }
+    if (ok)
+        updateServicesMap();
+
     Q_FOREACH(const QString &path,orderedServicesList) {
         if (list.indexOf((path)) == -1) {
             qDebug() << Q_FUNC_INFO << "removed" << path;
@@ -227,7 +229,7 @@ void QConnectionManager::serviceErrorChanged(const QString &error)
 void QConnectionManager::serviceStateChanged(const QString &state)
 {
     NetworkService *service = static_cast<NetworkService *>(sender());
-    qDebug() << state << service->name();
+    qDebug() << state << service->name() << service->strength();
 
     if (currentNetworkState == "disconnect") {
         ua->sendConnectReply("Clear");
@@ -255,7 +257,11 @@ void QConnectionManager::serviceStateChanged(const QString &state)
             && state == "online") {
         serviceInProgress.clear();
     }
-
+    if (state == "online" && service->type() == "cellular") {
+        // on gprs, scan wifi every scanTimeoutInterval minutes
+        if (scanTimeoutInterval != 0)
+            QTimer::singleShot(scanTimeoutInterval * 60 * 1000, this,SLOT(scanTimeout()));
+    }
     //auto migrate
     if (state == "idle") {
         if (lastManuallyConnectedService == service->path()) {
@@ -445,6 +451,7 @@ void QConnectionManager::updateServicesMap()
         QVector<NetworkService*> services = netman->getServices(tech);
 
         Q_FOREACH (NetworkService *serv, services) {
+            qDebug() << "known service:" << serv->name() << serv->strength();
 
             servicesMap.insert(serv->path(), serv);
             orderedServicesList << serv->path();
@@ -646,19 +653,24 @@ void QConnectionManager::setup()
         updateServicesMap();
         offlineModeChanged(netman->offlineMode());
 
+        QSettings confFile;
+        confFile.beginGroup("Connectionagent");
+        scanTimeoutInterval = confFile.value("scanTimerInterval", "1").toUInt(); //in minutes
+
         if (isStateOnline(netman->state())) {
             qDebug() << "default route type:" << netman->defaultRoute()->type();
             previousConnectedService = netman->defaultRoute()->path();
 
             if (netman->defaultRoute()->type() == "ethernet")
                 isEthernet = true;
+            if (netman->defaultRoute()->type() == "cellular" && scanTimeoutInterval != 0)
+                    QTimer::singleShot(scanTimeoutInterval * 60 * 1000, this,SLOT(scanTimeout()));
+
         } else
             netman->setSessionMode(true); //turn off connman autoconnecting
                                           // in later versions (1.18) this won't effect autoconnect
                                           // so we will have to turn it off some other way
 
-        QSettings confFile;
-        confFile.beginGroup("Connectionagent");
         qDebug() << "config file says" << confFile.value("connected", "online").toString();
         if (netman->state() != "online"
                 && (!isEthernet && confFile.value("connected", "online").toString() == "online")) {
@@ -732,11 +744,8 @@ bool QConnectionManager::isStateOnline(const QString &state)
 void QConnectionManager::requestDisconnect(const QString &servicePath)
 {
     if (servicesMap.contains(servicePath)) {
-        qDebug() << servicePath << "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<";
-
-        QDBusInterface service("net.connman", servicePath.toLocal8Bit(),
-                               "net.connman.Service", QDBusConnection::systemBus());
-        QDBusMessage reply = service.call(QDBus::NoBlock, QStringLiteral("Disconnect"));
+        qDebug() << servicePath;
+        servicesMap.value(servicePath)->requestDisconnect();
     }
 }
 
@@ -745,11 +754,10 @@ void QConnectionManager::requestConnect(const QString &servicePath)
     if (servicesMap.contains(servicePath)) {
         qDebug() << servicePath;
          serviceInProgress = servicePath;
-
-        QDBusInterface service("net.connman", servicePath.toLocal8Bit(),
-                               "net.connman.Service", QDBusConnection::systemBus());
-        QDBusMessage reply = service.call(QDBus::NoBlock, QStringLiteral("Connect"));
-        autoConnectService = servicePath;
+         if (netman->defaultRoute()->connected()) {
+             requestDisconnect(netman->defaultRoute()->path());
+         }
+         servicesMap.value(servicePath)->requestConnect();
     }
 }
 
@@ -800,7 +808,16 @@ void QConnectionManager::connectionTimeout()
 void QConnectionManager::serviceAutoconnectChanged(bool on)
 {
     qDebug() << on;
-    if (on) {
-        autoConnect();
+    autoConnect();
+}
+
+void QConnectionManager::scanTimeout()
+{
+    NetworkTechnology *wifiTech = netman->getTechnology("wifi");
+    qDebug() << netman->defaultRoute()->type()  << wifiTech->powered() << wifiTech->connected();
+    if (wifiTech && wifiTech->powered() && !wifiTech->connected() && netman->defaultRoute()->type() != "wifi" ) {
+        wifiTech->scan();
+        if (scanTimeoutInterval != 0)
+            QTimer::singleShot(scanTimeoutInterval * 60 * 1000, this,SLOT(scanTimeout()));
     }
 }

--- a/connd/qconnectionmanager.h
+++ b/connd/qconnectionmanager.h
@@ -101,7 +101,6 @@ private:
     bool handoverInProgress;
     QString previousConnectedService;
     QString serviceInProgress;
-    QString autoConnectService;
 
     bool isBestService(const QString &servicePath);
     bool isStateOnline(const QString &state);
@@ -116,6 +115,7 @@ private:
 
     QElapsedTimer manualConnnectionTimer;
     QString lastManuallyConnectedService;
+    uint scanTimeoutInterval;
 
 private slots:
     void onScanFinished();
@@ -151,6 +151,7 @@ private slots:
 
     void connectionTimeout();
     void serviceAutoconnectChanged(bool);
+    void scanTimeout();
 
 };
 


### PR DESCRIPTION
This helps autoconnect when coming from cell network back into wlan
range. connman's own background scan can take up to 5 minutes (or longer)

This timer does not run when defaultRoute is wifi.

This value can be changed in .config/nemomobile/connectionagent.conf

If this value is 0, no additional helper scanning is done.
