### PR TITLE
[connectionagent] reset serviceInProgress.

### DIFF
--- a/connd/qconnectionmanager.cpp
+++ b/connd/qconnectionmanager.cpp
@@ -907,6 +907,7 @@ void QConnectionManager::goodConnectionTimeout()
         } else {
             numberOfRetries = 0;
             errorReported(serviceInProgress,"limited connection");
+            serviceInProgress.clear();
         }
     }
 }


### PR DESCRIPTION
When the goodConnectionTimer fails for the third time, resetting the
serviceInProgress enables connecting again.
