### PR TITLE
[connectionagent] Treat connectToType() as manual connection.

### DIFF
--- a/connd/qconnectionmanager.cpp
+++ b/connd/qconnectionmanager.cpp
@@ -389,7 +389,11 @@ void QConnectionManager::connectToType(const QString &type)
             if (service) {
                 if (service->favorite() && service->autoConnect()) {
                     needConfig = false;
-                    connectToNetworkService(path);
+                    if (!connectToNetworkService(path))
+                        continue;
+
+                    lastManuallyConnectedService = serviceInProgress;
+                    manualConnnectionTimer.start();
                     break;
                 }
             }


### PR DESCRIPTION
This makes connectionagent treat network services connected using the
connectToType() method as manually connected service.

If connectToNetworkService() fails, keep trying with other applicable
services.
