### PR TITLE
[connectionagent] Suppress unnecessary roaming requests.

### DIFF
--- a/connd/qconnectionmanager.cpp
+++ b/connd/qconnectionmanager.cpp
@@ -575,7 +575,7 @@ QString QConnectionManager::findBestConnectableService()
             return QString(); // prefer connected wifi
 
         bool isCellRoaming = false;
-        if (service->type() == "cellular" && service->roaming()) {
+        if (service->type() == "cellular" && service->roaming() && !service->connected()) {
 
             isCellRoaming = askForRoaming;
 


### PR DESCRIPTION
If a cellular network service is already connected, no ask the user for
confirmation of roaming.
