### PR TITLE
[connectionagent] change good connect timer logic.

### DIFF
--- a/connd/qconnectionmanager.h
+++ b/connd/qconnectionmanager.h
@@ -45,7 +45,7 @@ class QConnectionManager : public QObject
 
 public:
     ~QConnectionManager();
-    
+
     static QConnectionManager &instance();
     bool askRoaming() const;
     void setAskRoaming(bool value);
@@ -121,7 +121,6 @@ private:
 
     QString delayedConnectService;
     void delayedConnect();
-    int numberOfRetries;
     QTimer *scanTimer;
 
     QMap <QString, QList <uint> > wifiStrengths;


### PR DESCRIPTION
This was causing many disconnect/reconnect when it retried, and
was confusing for some users.

Now this times out in 45 seconds, checks for online state. If it
is still in 'ready' state, will disconnect.

If this is still in association state, presume connman is stuck,
and power cycle the wifi tech, as this is the only way it seems
to be able to reset in this situation.
