### PR TITLE
[connectionagent] fix wonky connection at boot up.

### DIFF
--- a/connd/qconnectionmanager.cpp
+++ b/connd/qconnectionmanager.cpp
@@ -787,6 +787,11 @@ void QConnectionManager::browserRequest(const QString &servicePath, const QStrin
     goodConnectTimer->setInterval(5 * 60 * 1000);//may take user up to 5 mintues to figure out the passphrase
     goodConnectTimer->start();
 
+    if (netman->defaultRoute()->type() == "cellular") {
+        lastManuallyDisconnectedService = netman->defaultRoute()->path();
+        requestDisconnect(netman->defaultRoute()->path());
+    }
+
     Q_EMIT requestBrowser(url);
 }
 


### PR DESCRIPTION
Slightly delay the starting of the connection can help it 'settle'
so the attempt is sucessful.

Also, remove the session start so connman handles more of the autoconnection.
Since we now allow two connections, connman handle the
autoconnect some of the times (like bootup).

It still has problems with default route handling, so we just leave
the disconnect.
