### PR TITLE
[connectionagent] Don't automatically turn on tech power.

### DIFF
--- a/connd/qconnectionagent.cpp
+++ b/connd/qconnectionagent.cpp
@@ -259,9 +259,6 @@ void QConnectionAgent::connectToType(const QString &type)
     NetworkTechnology netTech;
     netTech.setPath(techPath);
 
-    if (!netTech.powered()) { // user has indicated they want a connection
-        netTech.setPowered(true);
-    }
     QStringList servicesList = netman->servicesList(type);
     bool needConfig = true;
 


### PR DESCRIPTION
If the user has explicitly turned the power off for a particular
technology don't turn it back on. Instead fail and and emit
configurationNeeded() which will trigger the system connection
selector dialog.
