### PR TITLE
[connectionagent] Remove debug print

### DIFF
--- a/connectionagentplugin/connectionagentplugin.cpp
+++ b/connectionagentplugin/connectionagentplugin.cpp
@@ -48,8 +48,6 @@ ConnectionAgentPlugin::~ConnectionAgentPlugin()
 
 void ConnectionAgentPlugin::connectToConnectiond(QString)
 {
-    qDebug() << Q_FUNC_INFO;
-
     if (connManagerInterface) {
         delete connManagerInterface;
         connManagerInterface = 0;


### PR DESCRIPTION
This debug print shows "program execution reached this point" even though no error happened. Thus it gets printed every time even in normal operation. It would be better to inform about problems instead.
