### PR TITLE
[connectionagent] Initialize delayedTethering member

### DIFF
--- a/connd/qconnectionagent.cpp
+++ b/connd/qconnectionagent.cpp
@@ -65,7 +65,8 @@ QConnectionAgent::QConnectionAgent(QObject *parent) :
     tetheringWifiTech(0),
     tetheringEnabled(false),
     flightModeSuppression(false),
-    scanTimeoutInterval(1)
+    scanTimeoutInterval(1),
+    delayedTethering(false)
 {
     qDebug() << Q_FUNC_INFO;
 


### PR DESCRIPTION
Fixes an uninitialized value warning from valgrind.
