### PR TITLE
[connectionagent] delay setting tethering enabled after power on.

### DIFF
--- a/connd/qconnectionagent.h
+++ b/connd/qconnectionagent.h
@@ -145,6 +145,7 @@ private slots:
     void servicesChanged();
 
     void openConnectionDialog(const QString &type);
+    void setWifiTetheringEnabled();
 };
 
 #endif // QCONNECTIONAGENT_H


### PR DESCRIPTION
This fixes the case when wifi needs to be powered on, and there are no
known services in range. For some reason, setting the technology to be
tethering enabled does not work until it is delayed.
