### PR TITLE
[connectionagent] disconnect mobile data if wifi becomes ready

### DIFF
--- a/connd/qconnectionagent.cpp
+++ b/connd/qconnectionagent.cpp
@@ -249,6 +249,11 @@ void QConnectionAgent::serviceStateChanged(const QString &state)
     if (delayedTethering && service->type() == "wifi" && state == "association") {
         service->requestDisconnect();
     }
+    if (state == "ready" && service->type() == "wifi"
+            && !delayedTethering
+            && netman->defaultRoute()->type() == "cellular") {
+        netman->defaultRoute()->requestDisconnect();
+    }
     if (state == "online") {
         Q_EMIT connectionState(state, service->type());
 


### PR DESCRIPTION
This is a workaround when there is active socket on mobile data and wifi becomes in ready state. connman would not make wifi default route.
