### PR TITLE
[connectionagent] Suppress errors when enabling tethering.

### DIFF
--- a/connd/qconnectionagent.cpp
+++ b/connd/qconnectionagent.cpp
@@ -153,10 +153,14 @@ void QConnectionAgent::onUserInputCanceled()
 // from useragent
 void QConnectionAgent::onErrorReported(const QString &servicePath, const QString &error)
 {
-    if (error == "connect-failed"
-            && (servicePath.contains("cellular") && netman->offlineMode())) {
-     return;
-    }
+    // Suppress errors when switching to offline mode
+    if (error == "connect-failed" && servicePath.contains("cellular") && netman->offlineMode())
+        return;
+
+    // Suppress errors when switching to tethering mode
+    if ((delayedTethering || tetheringWifiTech->tethering()) && servicePath.contains(QStringLiteral("wifi")))
+        return;
+
     qDebug() << "<<<<<<<<<<<<<<<<<<<<" << servicePath << error;
     Q_EMIT errorReported(servicePath, error);
 }


### PR DESCRIPTION
Enabling tethering when wlan is not powered causes it to first be
powered on. Connman will initiate a scan and may attempt to connect to
a known network. The wifi technology will then be switched to tethering
mode causing any in progress wlan connection to abort with an error
notification.

As these error notifications are expected, suppress them.
