### PR TITLE
[connectionagent] Do not send connectionRequest if there is a service

### DIFF
--- a/connd/qconnectionagent.cpp
+++ b/connd/qconnectionagent.cpp
@@ -170,7 +170,15 @@ void QConnectionAgent::onConnectionRequest()
 {
     sendConnectReply("Suppress", 15);
     qDebug() << flightModeSuppression;
-    if (!flightModeSuppression) {
+    bool okToRequest = true;
+    Q_FOREACH (const QString &path, servicesMap.keys()) {
+        qDebug() << "checking" <<servicesMap.value(path)->name() << servicesMap.value(path)->autoConnect();
+        if (servicesMap.value(path)->autoConnect()) {
+            okToRequest = false;
+            break;
+        }
+    }
+    if (!flightModeSuppression && okToRequest) {
         Q_EMIT connectionRequest();
     }
 }


### PR DESCRIPTION
available that is auto connectable.

This fixes condition when changing from one tech to another and
there is a dns lookup error that causes a connectionRequest from
connman in the moment between connections.
