### PR TITLE
[connectionagent] do not continue connectToType("cellular") if autoconnect is not enabled

### DIFF
--- a/connd/qconnectionagent.cpp
+++ b/connd/qconnectionagent.cpp
@@ -311,6 +311,9 @@ void QConnectionAgent::connectToType(const QString &type)
                     qDebug() << "<<<<<<<<<<< requestConnect() >>>>>>>>>>>>";
                     servicesMap.value(path)->requestConnect();
                     return;
+                } else if (path.contains("cellular")) {
+                    // do not continue if cellular is not autoconnect
+                    return;
                 }
             } else {
                 return;


### PR DESCRIPTION
fixes issue with apps using gps and requesting connection for apgs when autoconnect is disabled.
