### PR TITLE
Telemetry fixes

### DIFF
--- a/connd/qconnectionagent.h
+++ b/connd/qconnectionagent.h
@@ -26,6 +26,7 @@
 #include <QQueue>
 #include <QPair>
 #include <QElapsedTimer>
+#include <QVector>
 
 class UserAgent;
 class SessionAgent;
@@ -77,6 +78,42 @@ public Q_SLOTS:
     void stopTethering(bool keepPowered = false);
 
 private:
+
+    class Service
+    {
+    public:
+            QString path;
+            NetworkService *service;
+
+            bool operator==(const Service &other) const {
+                    return other.path == path;
+            }
+    };
+
+    class ServiceList : public QVector<Service>
+    {
+    public:
+            int indexOf(const QString &path, int from = 0) const {
+                    Service key;
+                    key.path = path;
+                    return QVector<Service>::indexOf(key, from);
+            }
+
+            bool contains(const QString &path) const {
+                    Service key;
+                    key.path = path;
+                    return QVector<Service>::indexOf(key) >= 0;
+            }
+
+            void remove(const QString &path) {
+                    Service key;
+                    key.path = path;
+                    int pos = QVector<Service>::indexOf(key);
+                    if (pos >= 0)
+                            QVector<Service>::remove(pos);
+            }
+    };
+
     explicit QConnectionAgent(QObject *parent = 0);
     static QConnectionAgent *self;
     ConnAdaptor *connectionAdaptor;
@@ -87,8 +124,7 @@ private:
 
     QString currentNetworkState;
 
-    QMap<QString,NetworkService *> servicesMap;
-    QStringList orderedServicesList;
+    ServiceList orderedServicesList;
 
     QStringList techPreferenceList;
     bool isEthernet;
@@ -112,7 +148,7 @@ private:
 
 private slots:
     void onScanFinished();
-    void updateServicesMap();
+    void updateServices();
 
     void serviceErrorChanged(const QString &error);
     void serviceStateChanged(const QString &state);
@@ -126,7 +162,6 @@ private slots:
     void browserRequest(const QString &servicePath, const QString &url);
     void techChanged();
 
-    void serviceRemoved(const QString &);
     void serviceAdded(const QString &);
     void servicesListChanged(const QStringList &);
     void offlineModeChanged(bool);


### PR DESCRIPTION
Null pointer check made for preventing a simple crash.

To make the code simpler, removed service hash map and modified the ordered service list to contain both the service path and pointer to service. This way we don't need to keep two separate data structures in sync. Most of the code accesses all the hash keys in linear order, retrieving a single value by key is used only in a couple of places, and the number of services is never very large so there should not be a big performance impact.
