### PR TITLE
[connectionagent] recommit do not continue connectToType("cellular") if autoconnect is not enabled

### DIFF
--- a/connd/qconnectionagent.cpp
+++ b/connd/qconnectionagent.cpp
@@ -324,6 +324,9 @@ void QConnectionAgent::connectToType(const QString &type)
                     qDebug() << "<<<<<<<<<<< requestConnect() >>>>>>>>>>>>";
                     elem.service->requestConnect();
                     return;
+                } else if (elem.path.contains("cellular")) {
+                    // do not continue if cellular is not autoconnect
+                    return;
                 }
             } else {
                 return;


### PR DESCRIPTION
This got reverted when https://github.com/nemomobile/connectionagent/pull/86 got merged after https://github.com/nemomobile/connectionagent/pull/83 by accident?
