### PR TITLE
Fix for building tst_connectionagent in non-default location

### DIFF
--- a/test/auto/tst_connectionagent/tst_connectionagent.pro
+++ b/test/auto/tst_connectionagent/tst_connectionagent.pro
@@ -18,7 +18,7 @@ HEADERS += \
         ../../../connd/connectiond_adaptor.h \
         ../../../connd/wakeupwatcher.h
 
-INCLUDEPATH += ../../../connd
+INCLUDEPATH += $$OUT_PWD/../../../connd
 
 CONFIG += link_pkgconfig
 PKGCONFIG += connman-qt5 qofono-qt5


### PR DESCRIPTION
Otherwise it doesn't find generated connectiond_adaptor.h
